### PR TITLE
Remove unneeded mkdir instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN pip3 install flask
 COPY ./apache2/* /
 
 # Copy over the Flask app
-RUN mkdir -p /app
 COPY ./app/* /app/
 
 # Create a WSGI VirtualServer for the Flask app (000 prefix to put it first)


### PR DESCRIPTION
Tested that `README` instructions still work after the changes.

Fixes #1

Signed-off-by: Clement Ng <clementdng@gmail.com>